### PR TITLE
fix: orchestrator tools always returning "Error: None"

### DIFF
--- a/backend/services/graph/tools.py
+++ b/backend/services/graph/tools.py
@@ -3109,7 +3109,7 @@ async def spawn_worker(
         wait=wait,
     )
 
-    if "error" in result:
+    if result.get("error"):
         return f"Error: {result['error']}"
 
     if wait:
@@ -3139,7 +3139,7 @@ async def check_worker(task_id: str) -> str:
     from services.orchestrator_service import get_task
 
     result = await get_task(task_id)
-    if "error" in result:
+    if result.get("error"):
         return f"Error: {result['error']}"
 
     status = result["status"]
@@ -3209,7 +3209,7 @@ async def cancel_worker(task_id: str) -> str:
     from services.orchestrator_service import cancel_task
 
     result = await cancel_task(task_id)
-    if "error" in result:
+    if result.get("error"):
         return f"Error: {result['error']}"
     return f"Worker {task_id[:8]}... cancelled. Status: {result['status']}"
 
@@ -3235,7 +3235,7 @@ async def wait_for_workers(task_ids: str) -> str:
 
     lines = []
     for r in results:
-        if "error" in r and not r.get("status"):
+        if r.get("error") and not r.get("status"):
             lines.append(f"- Error: {r['error']}")
             continue
         desc = r.get("task_description", "unknown")[:60]
@@ -3270,7 +3270,7 @@ async def send_to_worker(task_id: str, message: str) -> str:
     from services.orchestrator_service import send_message_to_worker
 
     result = await send_message_to_worker(task_id, message)
-    if "error" in result:
+    if result.get("error"):
         return f"Error: {result['error']}"
     return result.get("response", "No response")
 
@@ -3312,7 +3312,7 @@ async def spawn_cc_worker(task: str, cwd: Optional[str] = None, wait: bool = Tru
         wait=wait,
     )
 
-    if "error" in result:
+    if result.get("error"):
         return f"Error: {result['error']}"
 
     if wait:

--- a/backend/services/orchestrator_service.py
+++ b/backend/services/orchestrator_service.py
@@ -464,7 +464,7 @@ async def wait_for_tasks(task_ids: List[str], timeout: Optional[int] = None) -> 
 async def send_message_to_worker(task_id: str, message: str) -> dict:
     """Send a follow-up message to a completed worker's conversation."""
     task = await get_task(task_id)
-    if "error" in task:
+    if task.get("error"):
         return task
 
     if task["status"] == "running":


### PR DESCRIPTION
## Summary

All orchestrator tool calls (`spawn_worker`, `check_worker`, `cancel_worker`, `send_to_worker`, `spawn_cc_worker`, `wait_for_workers`) return `"Error: None"` even when the operation succeeds.

**What's happening**: `_task_to_dict()` always puts `"error": task.error` in its output dict — even when there's no error (value is `None`). Then every tool checks `if "error" in result:`, which asks "does this dictionary key exist?" — and yes, it always does. So every successful result gets treated as an error.

**Fix**: Changed all 7 checks to `result.get("error")`, which returns `None` (falsy) when the value is `None`, so successes pass through correctly now.

No changes to `_task_to_dict()` itself — the REST API may rely on the `error` field always being present.

## Files changed

- `backend/services/graph/tools.py` — 6 checks fixed
- `backend/services/orchestrator_service.py` — 1 check fixed

## Test plan

- [ ] Spawn a worker → verify task ID returned, not "Error: None"
- [ ] Check a completed worker → verify status and result shown
- [ ] Cancel a running worker → verify confirmation message
- [ ] Send message to completed worker → verify response returned