### PR TITLE
feat: add Anthropic prompt caching across all LLM call sites

### DIFF
--- a/backend/services/consolidation_service.py
+++ b/backend/services/consolidation_service.py
@@ -16,6 +16,8 @@ from typing import List, Tuple
 
 from sqlalchemy import select, func, or_, and_, delete
 
+from langchain_core.messages import SystemMessage, HumanMessage
+
 from services.database import (
     async_session,
     MemoryModel,
@@ -138,25 +140,28 @@ async def _run_consolidation_cycle() -> None:
             "type": m.memory_type,
         })
 
-    cluster_prompt = f"""Analyze these memories and group them into clusters by person, topic, or event.
+    cluster_instructions = """Analyze these memories and group them into clusters by person, topic, or event.
 Each memory should appear in at most one cluster. Only create clusters with 2+ memories.
 
-Memories:
-{json.dumps(memory_list, indent=2)}
-
 Return ONLY valid JSON with this structure:
-{{
+{
   "clusters": [
-    {{
+    {
       "label": "short description of what connects these",
       "type": "same_person | same_topic | same_event | related",
       "memory_ids": ["id1", "id2", ...]
-    }}
+    }
   ]
-}}"""
+}"""
 
     try:
-        cluster_response = await llm.ainvoke(cluster_prompt)
+        cluster_response = await llm.ainvoke([
+            SystemMessage(
+                content=cluster_instructions,
+                additional_kwargs={"cache_control": {"type": "ephemeral"}},
+            ),
+            HumanMessage(content=f"Memories:\n{json.dumps(memory_list, indent=2)}"),
+        ])
         haiku_calls += 1
         cluster_text = cluster_response.content
         # Extract JSON from response (handle markdown code blocks)
@@ -193,26 +198,29 @@ Return ONLY valid JSON with this structure:
             for mid in cluster_ids
         ]
 
-        contradiction_prompt = f"""Review these related memories for contradictions (conflicting facts, outdated info, or inconsistencies).
-
-Memories:
-{json.dumps(cluster_memories, indent=2)}
+        contradiction_instructions = """Review these related memories for contradictions (conflicting facts, outdated info, or inconsistencies).
 
 Return ONLY valid JSON:
-{{
+{
   "contradictions": [
-    {{
+    {
       "memory_id_a": "id of first memory",
       "memory_id_b": "id of second memory",
       "description": "brief description of the contradiction"
-    }}
+    }
   ]
-}}
+}
 
-If no contradictions found, return {{"contradictions": []}}"""
+If no contradictions found, return {"contradictions": []}"""
 
         try:
-            contradiction_response = await llm.ainvoke(contradiction_prompt)
+            contradiction_response = await llm.ainvoke([
+                SystemMessage(
+                    content=contradiction_instructions,
+                    additional_kwargs={"cache_control": {"type": "ephemeral"}},
+                ),
+                HumanMessage(content=f"Memories:\n{json.dumps(cluster_memories, indent=2)}"),
+            ])
             haiku_calls += 1
             contradiction_text = contradiction_response.content
             if "```" in contradiction_text:

--- a/backend/services/deep_retrieval_service.py
+++ b/backend/services/deep_retrieval_service.py
@@ -12,18 +12,15 @@ import re
 from typing import List
 
 from langchain_anthropic import ChatAnthropic
-from langchain_core.messages import HumanMessage
+from langchain_core.messages import HumanMessage, SystemMessage
 
 from services.memory_service import retrieve_memories, Memory
 from services.database import async_session, MemoryEnrichmentModel
 
 
-DEEP_QUERY_PROMPT = """Given this conversation, generate exactly 3 search queries to find relevant memories. The user's latest message may be short or ambiguous — use conversation context to infer what memories would be useful.
+DEEP_QUERY_INSTRUCTIONS = """Given this conversation, generate exactly 3 search queries to find relevant memories. The user's latest message may be short or ambiguous — use conversation context to infer what memories would be useful.
 
-Return ONLY a JSON array of 3 query strings.
-
-Last 5 messages:
-{conversation}"""
+Return ONLY a JSON array of 3 query strings."""
 
 
 async def should_deep_retrieve(message: str, conversation_id: str, turn_count: int) -> bool:
@@ -72,11 +69,16 @@ async def generate_search_queries(messages: list, model: str = "claude-haiku-4-5
         return []
 
     llm = ChatAnthropic(model=model, temperature=0, max_tokens=256)
-    prompt = DEEP_QUERY_PROMPT.format(conversation=conversation_text)
 
     try:
         response = await asyncio.wait_for(
-            llm.ainvoke([HumanMessage(content=prompt)]),
+            llm.ainvoke([
+                SystemMessage(
+                    content=DEEP_QUERY_INSTRUCTIONS,
+                    additional_kwargs={"cache_control": {"type": "ephemeral"}},
+                ),
+                HumanMessage(content=f"Last 5 messages:\n{conversation_text}"),
+            ]),
             timeout=3.0,
         )
 

--- a/backend/services/graph/streaming.py
+++ b/backend/services/graph/streaming.py
@@ -709,7 +709,10 @@ async def stream_with_memory_events(
     )
     now = datetime.now()
     time_context = f"\n\nCurrent date and time: {now.strftime('%A, %B %d, %Y at %I:%M %p')}"
-    enhanced_system_prompt = system_prompt + memory_context + briefing_context + time_context + ASSUMPTION_AWARENESS_CONTEXT + PLANNING_DIRECTIVE
+
+    # Split system prompt into static (cacheable) and dynamic (per-request) parts
+    static_system = system_prompt + ASSUMPTION_AWARENESS_CONTEXT + PLANNING_DIRECTIVE
+    dynamic_context = memory_context + briefing_context + time_context
 
     # Create LLM with dynamic tool binding
     llm = _build_llm(model, temperature)
@@ -736,7 +739,19 @@ async def stream_with_memory_events(
             yield create_event(EventType.THINKING, conversation_id, content="Thinking...")
 
         # Get response (may include tool calls)
-        full_messages = [SystemMessage(content=enhanced_system_prompt)] + messages
+        # Use two SystemMessages: static (cached) + dynamic (uncached)
+        full_messages = [
+            SystemMessage(content=static_system, additional_kwargs={"cache_control": {"type": "ephemeral"}}),
+            SystemMessage(content=dynamic_context),
+        ] + messages
+        # Add cache breakpoint on conversation history for multi-turn caching
+        if len(full_messages) > 3:
+            second_to_last = full_messages[-2]
+            if not getattr(second_to_last, 'additional_kwargs', {}).get('cache_control'):
+                second_to_last.additional_kwargs = {
+                    **getattr(second_to_last, 'additional_kwargs', {}),
+                    "cache_control": {"type": "ephemeral"},
+                }
         response = await llm_with_tools.ainvoke(full_messages)
 
         # Check if there are tool calls
@@ -877,8 +892,11 @@ async def stream_with_memory_events(
     # Only stream a new response if the loop didn't produce one
     if needs_streaming:
         print(f"[WARNING] Tool loop exited after {iteration}/{max_tool_iterations} iterations without final response, streaming new response")
-        fallback_prompt = enhanced_system_prompt + "\n\nYou have used all available tool iterations. Summarize what you accomplished and respond to the user. Do not attempt any more tool calls."
-        full_messages = [SystemMessage(content=fallback_prompt)] + messages
+        fallback_suffix = "\n\nYou have used all available tool iterations. Summarize what you accomplished and respond to the user. Do not attempt any more tool calls."
+        full_messages = [
+            SystemMessage(content=static_system, additional_kwargs={"cache_control": {"type": "ephemeral"}}),
+            SystemMessage(content=dynamic_context + fallback_suffix),
+        ] + messages
         llm_no_tools = _build_llm(model, temperature)
         async for chunk in llm_no_tools.astream(full_messages):
             if chunk.content:
@@ -1103,7 +1121,10 @@ async def chat_with_memory(
     )
     now = datetime.now()
     time_context = f"\n\nCurrent date and time: {now.strftime('%A, %B %d, %Y at %I:%M %p')}"
-    enhanced_system_prompt = system_prompt + memory_context + briefing_context_sync + orchestrator_context + time_context + ASSUMPTION_AWARENESS_CONTEXT + PLANNING_DIRECTIVE
+
+    # Split system prompt into static (cacheable) and dynamic (per-request) parts
+    static_system = system_prompt + ASSUMPTION_AWARENESS_CONTEXT + PLANNING_DIRECTIVE
+    dynamic_context = memory_context + briefing_context_sync + orchestrator_context + time_context
 
     # Create LLM with dynamic tool binding
     llm = _build_llm(model, temperature)
@@ -1125,7 +1146,19 @@ async def chat_with_memory(
         iteration += 1
 
         # Get response (may include tool calls)
-        full_messages = [SystemMessage(content=enhanced_system_prompt)] + messages
+        # Use two SystemMessages: static (cached) + dynamic (uncached)
+        full_messages = [
+            SystemMessage(content=static_system, additional_kwargs={"cache_control": {"type": "ephemeral"}}),
+            SystemMessage(content=dynamic_context),
+        ] + messages
+        # Add cache breakpoint on conversation history for multi-turn caching
+        if len(full_messages) > 3:
+            second_to_last = full_messages[-2]
+            if not getattr(second_to_last, 'additional_kwargs', {}).get('cache_control'):
+                second_to_last.additional_kwargs = {
+                    **getattr(second_to_last, 'additional_kwargs', {}),
+                    "cache_control": {"type": "ephemeral"},
+                }
         response = await llm_with_tools.ainvoke(full_messages)
 
         # Check if there are tool calls
@@ -1220,8 +1253,11 @@ async def chat_with_memory(
     # If we exhausted iterations, get final response without tools
     if not full_response:
         print(f"[WARNING] Tool loop exited after {iteration} iterations without final response, invoking fallback")
-        fallback_prompt = enhanced_system_prompt + "\n\nYou have used all available tool iterations. Summarize what you accomplished and respond to the user. Do not attempt any more tool calls."
-        full_messages = [SystemMessage(content=fallback_prompt)] + messages
+        fallback_suffix = "\n\nYou have used all available tool iterations. Summarize what you accomplished and respond to the user. Do not attempt any more tool calls."
+        full_messages = [
+            SystemMessage(content=static_system, additional_kwargs={"cache_control": {"type": "ephemeral"}}),
+            SystemMessage(content=dynamic_context + fallback_suffix),
+        ] + messages
         llm_no_tools = _build_llm(model, temperature)
         final_response = await llm_no_tools.ainvoke(full_messages)
         full_response = final_response.content

--- a/backend/services/heartbeat/triage_service.py
+++ b/backend/services/heartbeat/triage_service.py
@@ -336,7 +336,7 @@ async def _rule_pre_filter(
 
 # ===== Layer 2: Haiku classification =====
 
-TRIAGE_PROMPT = """You are Edward's triage classifier. Your job is to classify incoming messages by urgency.
+TRIAGE_INSTRUCTIONS = """You are Edward's triage classifier. Your job is to classify incoming messages by urgency.
 You are NOT acting on these messages — just classifying them so Edward can decide what to do.
 
 Be conservative: most messages should be DISMISS or NOTE. Only use ACT for messages that clearly require Edward to do something. Only use ESCALATE for genuinely urgent messages that need immediate attention.
@@ -346,11 +346,6 @@ For each event, return a classification:
 - NOTE: Worth remembering but no action needed (store a memory about this)
 - ACT: Edward should take action (reply, look something up, do a task)
 - ESCALATE: Urgent — needs Edward's immediate attention AND a push notification
-
-{contact_context}
-
-Events to classify:
-{events_digest}
 
 Return ONLY a valid JSON array with one object per event:
 [{{"event_id": "...", "classification": "DISMISS|NOTE|ACT|ESCALATE", "reasoning": "brief why", "note_content": "memory text if NOTE", "action_description": "what to do if ACT/ESCALATE"}}]"""
@@ -426,10 +421,7 @@ async def _haiku_classify(
     contact_context = await _build_contact_context(events)
     events_digest = _build_events_digest(events, config.digest_token_cap)
 
-    prompt = TRIAGE_PROMPT.format(
-        contact_context=contact_context or "No contact context available.",
-        events_digest=events_digest,
-    )
+    dynamic_data = f"{contact_context or 'No contact context available.'}\n\nEvents to classify:\n{events_digest}"
 
     llm = ChatAnthropic(
         model="claude-haiku-4-5-20251001",
@@ -438,7 +430,13 @@ async def _haiku_classify(
     )
 
     try:
-        response = await llm.ainvoke([HumanMessage(content=prompt)])
+        response = await llm.ainvoke([
+            SystemMessage(
+                content=TRIAGE_INSTRUCTIONS,
+                additional_kwargs={"cache_control": {"type": "ephemeral"}},
+            ),
+            HumanMessage(content=dynamic_data),
+        ])
 
         # Extract token usage
         input_tokens = 0

--- a/backend/services/memory_service.py
+++ b/backend/services/memory_service.py
@@ -311,16 +311,19 @@ async def store_memories(memories: List[Memory]) -> List[Memory]:
     return stored
 
 
+MERGE_INSTRUCTION = "Merge these two related memories into one clear, concise memory. Return ONLY the merged text, nothing else."
+
+
 async def _llm_merge_content(content_a: str, content_b: str, model: str = "claude-haiku-4-5-20251001") -> str:
     """Use Haiku to merge two memory contents into one clean version."""
     llm = ChatAnthropic(model=model, temperature=0, max_tokens=256)
-    prompt = f"""Merge these two related memories into one clear, concise memory:
-
-Memory A: {content_a}
-Memory B: {content_b}
-
-Return ONLY the merged text, nothing else."""
-    response = await llm.ainvoke([HumanMessage(content=prompt)])
+    response = await llm.ainvoke([
+        SystemMessage(
+            content=MERGE_INSTRUCTION,
+            additional_kwargs={"cache_control": {"type": "ephemeral"}},
+        ),
+        HumanMessage(content=f"Memory A: {content_a}\nMemory B: {content_b}"),
+    ])
     text = response.content
     if isinstance(text, list):
         text = " ".join(block.get("text", "") if isinstance(block, dict) else str(block) for block in text)
@@ -437,7 +440,7 @@ async def store_memories_with_conflict_detection(
     return stored
 
 
-MEMORY_EXTRACTION_PROMPT = """Analyze the following conversation and extract important information that should be remembered for future conversations.
+MEMORY_EXTRACTION_INSTRUCTIONS = """Analyze the following conversation and extract important information that should be remembered for future conversations.
 
 Focus on:
 1. **Personal facts** - Name, job, location, family, hobbies, etc.
@@ -470,13 +473,7 @@ IMPORTANT:
 - Group closely related facts about the same person into a single memory when possible. Prefer fewer, richer memories over many fragmented ones.
 - Don't store trivial greetings or small talk
 - Don't duplicate information already known
-- Be concise but complete
-
-Conversation:
-{conversation}
-
-Existing memories (don't duplicate these):
-{existing_memories}"""
+- Be concise but complete"""
 
 
 async def extract_and_store_memories(
@@ -527,16 +524,19 @@ async def extract_and_store_memories(
     # Call LLM to extract memories
     llm = ChatAnthropic(model=model, temperature=0, max_tokens=2048)
 
-    prompt = MEMORY_EXTRACTION_PROMPT.format(
-        conversation=conversation_text,
-        existing_memories=existing_text
-    )
+    dynamic_data = f"Conversation:\n{conversation_text}\n\nExisting memories (don't duplicate these):\n{existing_text}"
 
-    print(f"Memory extraction: prompt ready ({len(prompt)} chars)")
+    print(f"Memory extraction: prompt ready ({len(dynamic_data)} chars)")
 
     try:
         print(f"Memory extraction: calling LLM with {len(messages)} messages")
-        response = await llm.ainvoke([HumanMessage(content=prompt)])
+        response = await llm.ainvoke([
+            SystemMessage(
+                content=MEMORY_EXTRACTION_INSTRUCTIONS,
+                additional_kwargs={"cache_control": {"type": "ephemeral"}},
+            ),
+            HumanMessage(content=dynamic_data),
+        ])
         print(f"Memory extraction: got LLM response")
 
         # Handle both string and list content (Claude sometimes returns list of content blocks)
@@ -1064,19 +1064,7 @@ async def find_similar_memories(content: str, threshold: float = 0.85, limit: in
         ]
 
 
-CONFLICT_RESOLUTION_PROMPT = """You are analyzing two memories to determine how to handle a potential conflict or update.
-
-EXISTING MEMORY:
-- Content: {existing_content}
-- Type: {existing_type}
-- Importance: {existing_importance}
-
-NEW MEMORY:
-- Content: {new_content}
-- Type: {new_type}
-- Importance: {new_importance}
-
-Similarity score: {similarity:.2f}
+CONFLICT_RESOLUTION_INSTRUCTIONS = """You are analyzing two memories to determine how to handle a potential conflict or update.
 
 Determine the best action:
 - UPDATE: The new memory is an update/correction to the existing one (replace old with new)
@@ -1120,18 +1108,26 @@ async def resolve_memory_conflict(
     """
     llm = ChatAnthropic(model=model, temperature=0, max_tokens=512)
 
-    prompt = CONFLICT_RESOLUTION_PROMPT.format(
-        existing_content=existing.content,
-        existing_type=existing.memory_type,
-        existing_importance=existing.importance,
-        new_content=new.content,
-        new_type=new.memory_type,
-        new_importance=new.importance,
-        similarity=similarity
-    )
+    dynamic_data = f"""EXISTING MEMORY:
+- Content: {existing.content}
+- Type: {existing.memory_type}
+- Importance: {existing.importance}
+
+NEW MEMORY:
+- Content: {new.content}
+- Type: {new.memory_type}
+- Importance: {new.importance}
+
+Similarity score: {similarity:.2f}"""
 
     try:
-        response = await llm.ainvoke([HumanMessage(content=prompt)])
+        response = await llm.ainvoke([
+            SystemMessage(
+                content=CONFLICT_RESOLUTION_INSTRUCTIONS,
+                additional_kwargs={"cache_control": {"type": "ephemeral"}},
+            ),
+            HumanMessage(content=dynamic_data),
+        ])
 
         response_text = response.content
         if isinstance(response_text, list):
@@ -1173,16 +1169,13 @@ async def resolve_memory_conflict(
 
 # ===== TEMPORAL NATURE BACKFILL =====
 
-BACKFILL_PROMPT = """Classify each memory's temporal nature. Ben is the user.
+BACKFILL_INSTRUCTIONS = """Classify each memory's temporal nature. Ben is the user.
 
 - "timeless": Permanent facts unlikely to change (identity, allergies, family relationships, fixed preferences)
 - "temporary": Time-bound context that expires (current projects, upcoming events, temporary situations)
 - "evolving": Things that change over time and may be superseded (favorite restaurant, current job, tools in use)
 
-Return ONLY a valid JSON array of {{"id": "...", "temporal_nature": "..."}} for each memory.
-
-Memories:
-{memories_json}"""
+Return ONLY a valid JSON array of {{"id": "...", "temporal_nature": "..."}} for each memory."""
 
 
 async def backfill_temporal_nature(
@@ -1221,12 +1214,14 @@ async def backfill_temporal_nature(
                 for m in batch
             ]
 
-            prompt = BACKFILL_PROMPT.format(
-                memories_json=json.dumps(memories_for_prompt, indent=2)
-            )
-
             try:
-                response = await llm.ainvoke([HumanMessage(content=prompt)])
+                response = await llm.ainvoke([
+                    SystemMessage(
+                        content=BACKFILL_INSTRUCTIONS,
+                        additional_kwargs={"cache_control": {"type": "ephemeral"}},
+                    ),
+                    HumanMessage(content=f"Memories:\n{json.dumps(memories_for_prompt, indent=2)}"),
+                ])
                 response_text = response.content
                 if isinstance(response_text, list):
                     response_text = " ".join(
@@ -1275,7 +1270,7 @@ async def backfill_temporal_nature(
 
 # ===== TIER MIGRATION (ONE-TIME DEDUP + REINFORCE) =====
 
-DEDUP_CLASSIFY_PROMPT = """Review these groups of similar memories. For each group, decide the action:
+DEDUP_CLASSIFY_INSTRUCTIONS = """Review these groups of similar memories. For each group, decide the action:
 
 - MERGE: These are duplicates or near-duplicates. Provide a single clean merged version.
 - KEEP_ALL: These are genuinely distinct facts that should remain separate.
@@ -1286,24 +1281,21 @@ For MERGE groups, also classify the merged memory's temporal_nature:
 - "evolving": Changes over time (current job, favorite restaurant)
 
 Return ONLY valid JSON:
-{{
+{
   "groups": [
-    {{
+    {
       "action": "MERGE",
       "keep_id": "id of the best/most complete memory to keep",
       "absorb_ids": ["ids to delete after merging"],
       "merged_content": "single clean merged text",
       "temporal_nature": "timeless|temporary|evolving"
-    }},
-    {{
+    },
+    {
       "action": "KEEP_ALL",
       "memory_ids": ["id1", "id2"]
-    }}
+    }
   ]
-}}
-
-Memory groups:
-{groups_json}"""
+}"""
 
 
 async def backfill_memory_tiers(
@@ -1448,12 +1440,14 @@ async def _process_merge_groups(
     """Process a batch of merge groups via Haiku."""
     llm = ChatAnthropic(model=model, temperature=0, max_tokens=4096)
 
-    prompt = DEDUP_CLASSIFY_PROMPT.format(
-        groups_json=json.dumps(groups, indent=2)
-    )
-
     try:
-        response = await llm.ainvoke([HumanMessage(content=prompt)])
+        response = await llm.ainvoke([
+            SystemMessage(
+                content=DEDUP_CLASSIFY_INSTRUCTIONS,
+                additional_kwargs={"cache_control": {"type": "ephemeral"}},
+            ),
+            HumanMessage(content=f"Memory groups:\n{json.dumps(groups, indent=2)}"),
+        ])
         summary["haiku_calls"] += 1
 
         response_text = response.content

--- a/backend/services/reflection_service.py
+++ b/backend/services/reflection_service.py
@@ -14,22 +14,19 @@ from typing import List, Optional
 from datetime import datetime, timedelta
 
 from langchain_anthropic import ChatAnthropic
-from langchain_core.messages import HumanMessage
+from langchain_core.messages import HumanMessage, SystemMessage
 
 from services.database import async_session, MemoryEnrichmentModel
 from services.memory_service import retrieve_memories, Memory
 
 
-REFLECTION_QUERY_PROMPT = """Analyze this conversation and generate 3-5 search queries that would find relevant context from long-term memory. Focus on:
+REFLECTION_QUERY_INSTRUCTIONS = """Analyze this conversation and generate 3-5 search queries that would find relevant context from long-term memory. Focus on:
 
 1. People, places, or topics mentioned or implied
 2. Related context the user might expect you to remember
 3. Background information that would improve your next response
 
-Return ONLY a JSON array of query strings. Example: ["Ben's work projects", "previous discussions about Python", "Ben's preferences for code style"]
-
-Conversation (last 10 messages):
-{conversation}"""
+Return ONLY a JSON array of query strings. Example: ["Ben's work projects", "previous discussions about Python", "Ben's preferences for code style"]"""
 
 
 def should_reflect(messages: list, turn_count: int) -> bool:
@@ -75,11 +72,16 @@ async def generate_reflection_queries(messages: list, model: str = "claude-haiku
         return []
 
     llm = ChatAnthropic(model=model, temperature=0, max_tokens=512)
-    prompt = REFLECTION_QUERY_PROMPT.format(conversation=conversation_text)
 
     try:
         response = await asyncio.wait_for(
-            llm.ainvoke([HumanMessage(content=prompt)]),
+            llm.ainvoke([
+                SystemMessage(
+                    content=REFLECTION_QUERY_INSTRUCTIONS,
+                    additional_kwargs={"cache_control": {"type": "ephemeral"}},
+                ),
+                HumanMessage(content=f"Conversation (last 10 messages):\n{conversation_text}"),
+            ]),
             timeout=5.0,
         )
 

--- a/backend/services/search_tag_service.py
+++ b/backend/services/search_tag_service.py
@@ -43,7 +43,10 @@ async def generate_search_tags(conversation_id: str, messages: List[Dict[str, st
     )
 
     response = await llm.ainvoke([
-        SystemMessage(content=system),
+        SystemMessage(
+            content=system,
+            additional_kwargs={"cache_control": {"type": "ephemeral"}},
+        ),
         HumanMessage(content=conversation_text),
     ])
 


### PR DESCRIPTION
## Summary

Splits system prompts into static (cached) and dynamic (per-request) sections with `cache_control` markers for Anthropic's prompt caching API. This is a standalone extraction of the prompt caching work from PR #4, with no other feature changes.

**Pattern applied consistently across all call sites:**
- Static instruction text -> `SystemMessage` with `cache_control: {"type": "ephemeral"}`
- Dynamic data (conversation, memories, time) -> separate `HumanMessage` or uncached `SystemMessage`

### Files changed (7 files, 12 call sites)

| File | Call Sites | Description |
|------|-----------|-------------|
| `backend/services/graph/streaming.py` | 4 | Main chat (streaming + non-streaming) + fallback paths. Static system prompt cached, dynamic context uncached, conversation history cache breakpoint on `messages[-2]` |
| `backend/services/memory_service.py` | 5 | Memory extraction, merge, conflict resolution, temporal backfill, dedup classification |
| `backend/services/consolidation_service.py` | 2 | Cluster analysis and contradiction detection |
| `backend/services/deep_retrieval_service.py` | 1 | Multi-query generation for deep retrieval |
| `backend/services/reflection_service.py` | 1 | Post-turn reflection query generation |
| `backend/services/search_tag_service.py` | 1 | Search tag generation (added `cache_control` to existing `SystemMessage`) |
| `backend/services/heartbeat/triage_service.py` | 1 | Heartbeat triage Haiku classification |

### Expected savings

- **Main Sonnet chat path**: ~30-50% input token savings (system prompt + tools exceed 1024-token cache threshold)
- **Haiku call sites**: Consistent pattern applied but may not hit the 4096-token Haiku threshold for actual caching. No errors -- `cache_control` is silently ignored below threshold.

### What's NOT included

This PR contains only prompt caching changes. Other work from the `cl-feature` branch (cross-platform, autonomy framework, NotebookLM, etc.) is excluded.

## Test plan

- [ ] Backend starts without import errors
- [ ] Chat works normally (streaming + non-streaming paths)
- [ ] Memory extraction still produces valid memories after conversations
- [ ] No regressions in heartbeat triage, consolidation, reflection, or deep retrieval
